### PR TITLE
Add a list of users not attending the gathering

### DIFF
--- a/gathering/async/get.js
+++ b/gathering/async/get.js
@@ -56,23 +56,30 @@ function reduceUpdates (thread) {
 }
 
 function reduceAttendees (myKey, thread) {
-  const attendees = thread
+  const [attendees, unAttendees] = thread
     .filter(isAttendee)
-    .reduce((acc, msg) => {
+    .reduce(([accAttendee, accUnattendee], msg) => {
       const { link, remove } = msg.value.content.attendee
       // only trust attendee calls from people themselves for now
       if (msg.value.author !== link) return acc
 
       if (remove) {
-        return acc.filter(feedId => feedId !== link)
+        accAttendee = accAttendee.filter(feedId => feedId !== link)
+        if(!accUnattendee.includes(link)) {
+          accUnattendee = [...accUnattendee, link]
+        }
       } else {
-        if (acc.includes(link)) return acc
-        else return [...acc, link]
+        accUnattendee = accUnattendee.filter(feedId => feedId !== link)
+        if (!accAttendee.includes(link)) {
+          accAttendee = [...accAttendee, link]
+        }
       }
-    }, [])
+      return [accAttendee, accUnattendee]
+    }, [[], []])
 
   return {
     isAttendee: attendees.includes(myKey),
-    attendees
+    attendees,
+    unAttendees
   }
 }

--- a/gathering/async/get.test.js
+++ b/gathering/async/get.test.js
@@ -43,11 +43,13 @@ group('gathering.async.get', test => {
         ], 'has all images added')
 
         t.deepEqual(doc.attendees, [ server.id ], 'shows me attending')
+        t.deepEqual(doc.unAttendees, [], 'doesnt show me as not attending')
         scuttle.attendee.async.publish(gathering.key, false, (err, attendee) => {
           if (err) throw (err)
           scuttle.gathering.async.get(gathering.key, (err, doc) => {
             if (err) throw (err)
             t.deepEqual(doc.attendees, [], 'shows me no longer attending')
+            t.deepEqual(doc.unAttendees, [ server.id ], 'shows me as not attending')
 
             done()
           })


### PR DESCRIPTION
I took at stab at generating the list of users who are not attending the gathering. 
The corresponding changes in patchbay-gathering is in [my fork](https://github.com/hardfire/patchbay-gatherings) . 

It works in theory, but some things could be done better (especially the naming convention of "unattending"). A quick [search shows](https://english.stackexchange.com/questions/261805/the-opposite-of-attend) there isn't really an opposite of attending.